### PR TITLE
Support modern ansible and python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,7 @@ router_id: 192.0.2.2
 ```
 ---
 - hosts: arouteserver_hosts
-  become: yes
-    gather_facts: False
+  gather_facts: False
 
   vars:
     arouteserver_clients_from_euroix_url: "http://ixp-manager.example.com/api/v4/member-export/ixf/0.6?apikey=123456"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,11 +12,11 @@
 
 #arouteserver_notify_on_rs_change:
 
-arouteserver_venv_dir: "~/.virtualenvs/arouteserver"
-arouteserver_bin: "{{arouteserver_venv_dir}}/bin/arouteserver"
-arouteserver_dir: "~/arouteserver"
-arouteserver_var: "~/arouteserver_var"
-bgpq3_dir: "~/bgpq3"
+arouteserver_venv_dir: "{{ lookup('env', 'HOME') }}/.virtualenvs/arouteserver"
+arouteserver_bin: "{{ arouteserver_venv_dir }}/bin/arouteserver"
+arouteserver_dir: "{{ lookup('env', 'HOME') }}/arouteserver"
+arouteserver_var: "{{ lookup('env', 'HOME') }}/arouteserver_var"
+bgpq4_dir: "{{ lookup('env', 'HOME') }}/bgpq4"
 
 arouteserver_varname_rs_asn: "rs_asn"
 arouteserver_varname_daemon: "daemon"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,14 @@
 ---
 - name: "request reconfiguration of general policies"
   listen: "arouteserver: reconfigure general policies"
-  include_tasks: configure_general_policy.yml rs_hostname={{ item }}
+  include_tasks: configure_general_policy.yml
   with_items: "{{ groups['arouteserver_managed_routeservers'] }}"
+  loop_control:
+    loop_var: rs_hostname
+
 - name: "request rebuilding of rs configs"
   listen: "arouteserver: rebuild rs config files"
-  include_tasks: build_rs_config.yml rs_hostname={{ item }}
+  include_tasks: build_rs_config.yml
   with_items: "{{ groups['arouteserver_managed_routeservers'] }}"
+  loop_control:
+    loop_var: rs_hostname

--- a/tasks/bgpq3.yml
+++ b/tasks/bgpq3.yml
@@ -1,5 +1,6 @@
 ---
 - name: "install tools to build bgpq3"
+  become: True
   package:
     name: "{{ item }}"
     state: present
@@ -31,6 +32,7 @@
     "Nothing to be done" not in bgpq3_make.stdout
 
 - name: "bgpq3: install if compile changed"
+  become: True
   command: make install
   args:
     chdir: "{{ bgpq3_dir }}"

--- a/tasks/build_rs_config.yml
+++ b/tasks/build_rs_config.yml
@@ -39,13 +39,11 @@
 
 - name: "copy {{ rs_hostname }} config files to {{ arouteserver_dir }}"
   copy:
-    src: "{{ rs_d_file.path }}"
+    src: "{{ item.path }}"
     dest: "{{ arouteserver_dir }}/"
     remote_src: True
   with_items:
   - "{{ rs_d_content.files }}"
-  loop_control:
-    loop_var: rs_d_file
   register: rs_config_file
 
 - name: "notify on rs config change"

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -1,12 +1,13 @@
 ---
 - name: "install ARouteServer dependencies"
+  become: True
   package:
     name: "{{ item }}"
     state: present
   with_items:
-  - "{% if ansible_distribution == 'CentOS' %}python-devel{% else %}python-dev{% endif %}"
-  - python-pip
-  - python-virtualenv
+  - "{% if ansible_distribution == 'CentOS' %}python-devel{% else %}{% if ansible_python_version is version('3.0', '>=') %}python3-dev{% else %}python-dev{% endif %}{% endif %}"
+  - "{% if ansible_distribution == 'CentOS' %}python-pip{% else %}{% if ansible_python_version is version('3.0', '>=') %}python3-pip{% else %}python-pip{% endif %}{% endif %}"
+  - "{% if ansible_distribution == 'CentOS' %}python-virtualenv{% else %}{% if ansible_python_version is version('3.0', '>=') %}python3-virtualenv{% else %}python-virutalenv{% endif %}{% endif %}"
   - gcc
 
 - name: "upgrade pip and setuptools"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,13 +3,13 @@
   fail:
     msg: "Variable '{{ item[1] }}' for host '{{ item[0] }}' is not defined"
   when: hostvars[item[0]][item[1]] is not defined
-  with_nested:
-  - "{{ groups['arouteserver_managed_routeservers'] }}"
-  - - "{{ arouteserver_varname_rs_asn }}"
-    - "{{ arouteserver_varname_daemon }}"
-    - "{{ arouteserver_varname_daemon_version }}"
-    - "{{ arouteserver_varname_router_id }}"
-    - "{{ arouteserver_varname_local_networks }}"
+  loop: "{{ groups['arouteserver_managed_routeservers'] | product([
+    arouteserver_varname_rs_asn,
+    arouteserver_varname_daemon,
+    arouteserver_varname_daemon_version,
+    arouteserver_varname_router_id,
+    arouteserver_varname_local_networks
+    ]) | list }}"
   tags:
   - always
 
@@ -58,12 +58,13 @@
   include_tasks: installation.yml
 
 - name: "configure general policy (general.yml file)"
-  include_tasks: configure_general_policy.yml rs_hostname={{ item }}
+  include_tasks: configure_general_policy.yml
   with_items:
   - "{{ groups['arouteserver_managed_routeservers'] }}"
+  loop_control:
+    loop_var: rs_hostname
   tags:
   - configure_policy
-  changed_when: False
 
 - name: "configure client list (clients.yml file)"
   include_tasks: configure_client_list.yml
@@ -71,10 +72,11 @@
   - configure_clients
 
 - name: "rebuild rs config on build_rs_config tag"
-  include_tasks: build_rs_config.yml rs_hostname={{ item }}
+  include_tasks: build_rs_config.yml
   when: build_rs_configs_tag_is_not_present is not defined
   with_items:
   - "{{ groups['arouteserver_managed_routeservers'] }}"
+  loop_control:
+    loop_var: rs_hostname
   tags:
   - build_rs_config
-  changed_when: False


### PR DESCRIPTION
This updates a few aspects to support modern versions of Ansible:

- Use `become: True` only for the tasks that need it. This enables running `arouteserver` as a non-root user.
- `include_tasks` no longer supports passing in named variables directly; use `loop_control` instead.
- Install python3-based dependencies when ansible runs using python3 on the remote host. This enables support for modern Debian/Ubuntu versions which have removed Python2.