### PR TITLE
upgrade: fix logic and refactor to use variables instead of tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Most of the behaviours of this role can be set using some variables that are doc
 
 ### Installation
 
-ARouteServer is installed using `pip` via PyPI or from a local package on the control machine. When the `upgrade` tag is used, the `--upgrade` argument is passed to `pip` to allow an upgrade of the installation.
+ARouteServer is installed using `pip` via PyPI or from a local package on the control machine. When the ansible variable `arouteserver_upgrade` is set to `true` (defaults to `false`), the `--upgrade` argument is passed to `pip` to allow an upgrade of the installation.
 
 Any local file within the role's `templates/config` directory is copied into the ARouteServer's directory (Jinja2 templates are supported).
 
@@ -52,8 +52,6 @@ If set, an external handler is notified when the configuration files change.
 
 * `build_rs_config`: when set, only the route server configuration files are built.
 
-* `upgrade`: when set, an upgrade of the ARouteServer's package is attempted.
-
 ## Requirements
 
 No requirements.
@@ -65,6 +63,7 @@ Variables used by this role are listed below, grouped by topic.
 ### Package installation
 
 * (optional) `arouteserver_local_package_file`: when set, the role installs ARouteServer using the package at this local path, otherwise the last version from PyPI is fetched and installed (default).
+* (optional) `arouteserver_upgrade`; when set to `true` passes `--upgrade` to PIP to enable selective upgrades of the upstream `arouteserver` python package.
 
 ### Route server configuration: general policy (`general.yml`)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,8 @@
 # arouteserver_notify_on_rs_change:
 
 arouteserver_venv_dir: "{{ lookup('env', 'HOME') }}/.virtualenvs/arouteserver"
+# Don't upgrade the `arouteserver` python package on each run unless explicitly requested
+arouteserver_upgrade: false
 arouteserver_bin: "{{ arouteserver_venv_dir }}/bin/arouteserver"
 arouteserver_dir: "{{ lookup('env', 'HOME') }}/arouteserver"
 arouteserver_templates_dir: "{{ arouteserver_dir }}/templates"

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -17,13 +17,7 @@
       - pip
       - setuptools
     extra_args: "--upgrade"
-  tags:
-    - upgrade
-
-- name: "Is this an upgrade request ('upgrade' tag)?"
-  ansible.builtin.command: "true"
-  register: arouterserver_upgrade_not_present
-  changed_when: false
+  when: arouteserver_upgrade is defined and arouteserver_upgrade | bool
 
 # Option 1: install from PyPI repository when arouteserver_local_package_file is not set.
 # sets: arouteserver_pypi_install
@@ -31,7 +25,7 @@
   ansible.builtin.pip:
     virtualenv: "{{ arouteserver_venv_dir }}"
     name: arouteserver
-    extra_args: "{% if arouterserver_upgrade_not_present is not defined %}--upgrade{% endif %}"
+    extra_args: "{% if arouteserver_upgrade is defined and arouteserver_upgrade %}--upgrade{% endif %}"
   register: arouteserver_pypi_install
   changed_when: >
     arouteserver_pypi_install.stdout is defined and (
@@ -39,8 +33,6 @@
     "Successfully installed arouteserver" in arouteserver_pypi_install.stdout
     )
   when: arouteserver_local_package_file is undefined or not arouteserver_local_package_file
-  tags:
-    - upgrade
 
 # Option 2: install from local file when arouteserver_local_package_file is set.
 # sets: arouteserver_local_package
@@ -49,37 +41,37 @@
     src: "{{ arouteserver_local_package_file }}"
     dest: "{{ arouteserver_var }}/arouteserver.tar.gz"
     mode: ug=rw,o=r
-  when: arouteserver_local_package_file is defined and arouteserver_local_package_file
+  when: >
+    arouteserver_local_package_file is defined
+    and
+    arouteserver_local_package_file
+    and
+    arouteserver_upgrade
   register: arouteserver_local_package
-  tags:
-    - upgrade
 
 - name: "Install local package via pip"
   ansible.builtin.pip:
     virtualenv: "{{ arouteserver_venv_dir }}"
     name: "{{ arouteserver_var }}/arouteserver.tar.gz"
-    extra_args: "{% if arouterserver_upgrade_not_present is not defined %}--upgrade{% endif %}"
+    extra_args: "{% if arouteserver_upgrade is defined and arouteserver_upgrade %}--upgrade{% endif %}"
   register: arouteserver_local_install
   changed_when: >
     "for arouteserver: finished with status 'done'" in arouteserver_local_install.stdout or
     "Successfully installed arouteserver" in arouteserver_local_install.stdout
   when: arouteserver_local_package_file is defined and arouteserver_local_package_file and arouteserver_local_package.changed
-  tags:
-    - upgrade
 
 - name: "Does the arouteserver directory exist?"
   ansible.builtin.stat:
     path: "{{ arouteserver_dir }}"
   register: arouteserver_dir_exists
-  tags:
-    - upgrade
 
 - name: "Run 'arouteserver setup'"
   ansible.builtin.command: "{{ arouteserver_bin }} setup --dest-dir {{ arouteserver_dir }}"
   register: arouteserver_setup
-  when: not arouteserver_dir_exists.stat.exists
-  tags:
-    - upgrade
+  when: >
+    not arouteserver_dir_exists.stat.exists
+    and
+    arouteserver_upgrade
   changed_when: true
 
 - name: "Copy any local custom file to {{ arouteserver_dir }}"
@@ -93,11 +85,15 @@
 
 - name: "Run 'arouteserver setup-templates'"
   ansible.builtin.command: "{{ arouteserver_bin }} setup-templates"
-  when: arouteserver_pypi_install.changed or
-        arouteserver_local_install.changed
+  when: >
+    (
+      arouteserver_pypi_install.changed
+      or
+      arouteserver_local_install.changed
+    )
+    and
+    arouteserver_upgrade
   notify:
     - "arouteserver: reconfigure general policies"
     - "arouteserver: rebuild rs config files"
-  tags:
-    - upgrade
   changed_when: true


### PR DESCRIPTION
The upgrade functionality using tags seems a bit strange -- I don't actually think it properly supports upgrading.

[This task](https://github.com/pierky/ansible-role-arouteserver/blob/e05b6e7fa0f07f79300fb6d3a05f8fcb1f3f6b3c/tasks/installation.yml#L23-L26) always runs, and then registers the variable arouterserver_upgrade_not_present, but then the actual upgrade of arouteserver python only happens if that variable is unset. So..... how's that supposed to work?

This PR additionally overhauls this functionality to use an ansible variable `arouteserver_upgrade` instead of a tag so that this upgrade could also happen inside of a larger play.